### PR TITLE
「前端」比赛板块设计的进一步修整与若干细节的调整

### DIFF
--- a/BackEnd/app/api/competition_endpoints.py
+++ b/BackEnd/app/api/competition_endpoints.py
@@ -19,7 +19,7 @@ from app.services.competition_service import (
     create_competition_announcement,
     delete_competition_announcement,
     register_competition_service,
-    get_competition_teams_info, list_competition_levels
+    get_competition_teams_info
 )
 from app.services.auth_service import get_current_user
 from app.schemas.competition import (
@@ -41,10 +41,7 @@ def create_competition_endpoint(
     """
     创建比赛：仅管理员。保持前端 JSON 返回样式不变（由 Pydantic response_model 保证）。
     """
-    competition = create_competition(db, competition_in, current_user.role)
-    competition.competition_level = competition.competition_level_ref.zh_CN
-    competition.competition_subtype = competition.competition_subtype_ref.zh_CN
-    return competition
+    return create_competition(db, competition_in, current_user.role)
 
 
 @router.get("/", response_model=List[Competition])
@@ -55,35 +52,9 @@ def list_competitions_endpoint(
     """
     列出全部比赛
     """
-    model_competitions = list_competitions(db)
-    schema_competitions = list()
-    for model_competition in model_competitions:
-        add_schema_competition = model_competition
-        add_schema_competition.competition_level = model_competition.competition_level_ref.zh_CN
-        add_schema_competition.competition_subtype = model_competition.competition_subtype_ref.zh_CN
-        schema_competitions.append(add_schema_competition)
+    return list_competitions(db)
 
-    return schema_competitions
-
-@router.get("/levels")
-def list_competition_levels_endpoint(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    model_levels = list_competition_levels(db)
-    schema_levels = list()
-
-    for model_level in model_levels:
-        add_schema_level = model_level
-        add_schema_level.translation = model_level.zh_CN
-        for add_schema_subtype in add_schema_level.subtypes:
-            add_schema_subtype.translation = add_schema_subtype.zh_CN
-
-        schema_levels.append(add_schema_level)
-
-    return schema_levels
-
-@router.get("/detail/{competition_id}")
+@router.get("/detail/{competition_id}", response_model=Competition)
 def get_competition_detail_endpoint(
     competition_id: int,
     db: Session = Depends(get_db),
@@ -93,13 +64,16 @@ def get_competition_detail_endpoint(
     获取比赛详情（保持现有 JSON 结构：在 Competition 基础上附带 announcements）。
     注：沿用原先的 __dict__ 组合返回，避免破坏前端字段名/结构。
     """
+
+    """
     competition = get_competition_detail_info(db, competition_id)
-    competition.competition_level = competition.competition_level_ref.zh_CN
-    competition.competition_subtype = competition.competition_subtype_ref.zh_CN
+    
     return {
         **competition.__dict__,
         "announcements": competition.announcements
     }
+    """
+    return get_competition_detail_info(db, competition_id)
 
 @router.put("/update/{competition_id}", response_model=Competition)
 def update_competition_endpoint(
@@ -111,10 +85,7 @@ def update_competition_endpoint(
     """
     更新比赛：仅管理员
     """
-    competition = update_competition_info(db, competition_id, competition_in, current_user.role)
-    competition.competition_level = competition.competition_level_ref.zh_CN
-    competition.competition_subtype = competition.competition_subtype_ref.zh_CN
-    return competition
+    return update_competition_info(db, competition_id, competition_in, current_user.role)
 
 @router.delete("/{competition_id}")
 def delete_competition_endpoint(

--- a/BackEnd/app/db/models.py
+++ b/BackEnd/app/db/models.py
@@ -127,8 +127,8 @@ class Competition(Base):
 
     details = Column(String, nullable=True)
     organizer = Column(String, index=True, nullable=True)
-    competition_level_key = Column(String, ForeignKey("competition_levels.key"), index=True, nullable=True)
-    competition_subtype_key = Column(String, ForeignKey("competition_subtypes.key"), index=True, nullable=True)
+    competition_level = Column(String, index=True, nullable=True)
+    competition_subtype = Column(String, index=True, nullable=True)
     cover_image = Column(String, nullable=True)
 
     created_at = Column(DateTime, default=datetime.utcnow)
@@ -136,39 +136,6 @@ class Competition(Base):
 
     registrations = relationship("CompetitionRegistration", back_populates="competition")
     announcements = relationship("CompetitionAnnouncement", back_populates="competition")
-    competition_subtype_ref = relationship("CompetitionSubtype", back_populates="competitions")
-    competition_level_ref = relationship("CompetitionLevel", back_populates="competitions")
-
-class CompetitionLevel(Base):
-    """
-    比赛等级映射表
-    - key: 比赛等级键
-    - zh_CN: 中文翻译
-    """
-
-    __tablename__ = "competition_levels"
-
-    key = Column(String, primary_key=True, unique=True)
-    zh_CN = Column(String, nullable=False)
-
-    competitions = relationship("Competition", back_populates="competition_level_ref")
-    subtypes = relationship("CompetitionSubtype", back_populates="level_ref")
-
-class CompetitionSubtype(Base):
-    """
-    比赛子类型映射表
-    - key: 比赛子类型键
-    - zh_CN: 中文翻译
-    """
-
-    __tablename__ = "competition_subtypes"
-
-    key = Column(String, primary_key=True, unique=True)
-    level_key = Column(String, ForeignKey("competition_levels.key"), nullable=False)
-    zh_CN = Column(String, nullable=False)
-
-    competitions = relationship("Competition", back_populates="competition_subtype_ref")
-    level_ref = relationship("CompetitionLevel", back_populates="subtypes")
 
 class CompetitionRegistration(Base):
     """

--- a/BackEnd/app/schemas/competition.py
+++ b/BackEnd/app/schemas/competition.py
@@ -1,71 +1,8 @@
 # app/schemas/competition.py
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel
 from typing import Optional, List
-
-# ================== 比赛类型、等级、子类型相关模型 ===================
-class CompetitionSubtype(BaseModel):
-    key: str
-    translation: str
-
-    class Config:
-        orm_mode = True
-
-class CompetitionLevel(BaseModel):
-    key: str
-    translation: str
-    subtypes: List[CompetitionSubtype]
-
-    class Config:
-        orm_mode = True
-
-# ================== 比赛相关模型 ===================
-class CompetitionBase(BaseModel):
-    name: str
-    sign_up_start_time: datetime
-    sign_up_end_time: datetime
-    competition_start_time: datetime
-    competition_end_time: datetime
-    details: Optional[str] = None
-    organizer: Optional[str] = None
-    competition_level_key: Optional[str] = None
-    competition_subtype_key: Optional[str] = None
-    cover_image: Optional[str] = None
-
-class CompetitionCreate(CompetitionBase):
-    pass
-
-class CompetitionUpdate(BaseModel):
-    """
-    更新比赛时前端可能只传部分字段
-    """
-    name: Optional[str] = None
-    sign_up_start_time: Optional[datetime] = None
-    sign_up_end_time: Optional[datetime] = None
-    competition_start_time: Optional[datetime] = None
-    competition_end_time: Optional[datetime] = None
-    details: Optional[str] = None
-    organizer: Optional[str] = None
-    competition_level_key: Optional[str] = None
-    competition_subtype_key: Optional[str] = None
-    cover_image: Optional[str] = None
-
-class CompetitionInDBBase(CompetitionBase):
-    id: int
-    created_at: datetime
-    updated_at: datetime
-
-    class Config:
-        orm_mode = True
-
-class Competition(CompetitionInDBBase):
-    """
-    返回给前端的比赛信息
-    """
-    competition_level: Optional[str]
-    competition_subtype: Optional[str]
-
 
 # ================== 比赛公告相关模型 ===================
 class CompetitionAnnouncementBase(BaseModel):
@@ -97,6 +34,57 @@ class CompetitionAnnouncement(CompetitionAnnouncementInDBBase):
     返回给前端使用的公告模型
     """
     pass
+
+# ================== 比赛相关模型 ===================
+class CompetitionBase(BaseModel):
+    name: str
+    sign_up_start_time: datetime
+    sign_up_end_time: datetime
+    competition_start_time: datetime
+    competition_end_time: datetime
+    details: Optional[str] = None
+    organizer: Optional[str] = None
+    competition_level: Optional[str] = None
+    competition_subtype: Optional[str] = None
+    cover_image: Optional[str] = None
+
+class CompetitionCreate(CompetitionBase):
+    pass
+
+class CompetitionUpdate(BaseModel):
+    """
+    更新比赛时前端可能只传部分字段
+    """
+    name: Optional[str] = None
+    sign_up_start_time: Optional[datetime] = None
+    sign_up_end_time: Optional[datetime] = None
+    competition_start_time: Optional[datetime] = None
+    competition_end_time: Optional[datetime] = None
+    details: Optional[str] = None
+    organizer: Optional[str] = None
+    competition_level: Optional[str] = None
+    competition_subtype: Optional[str] = None
+    cover_image: Optional[str] = None
+
+class CompetitionInDBBase(CompetitionBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class Competition(CompetitionInDBBase):
+    """
+    返回给前端的比赛信息
+    """
+    announcements: Optional[List[CompetitionAnnouncement]] = None
+
+    class Config:
+        orm_mode = True
+        json_encoders = {
+            datetime: lambda v: v.replace(tzinfo=timezone.utc).isoformat()
+        }
 
 # ================== 用于返回比赛时，额外包含的字段 ===================
 class TeamBasicInfo(BaseModel):

--- a/BackEnd/app/services/competition_service.py
+++ b/BackEnd/app/services/competition_service.py
@@ -16,7 +16,7 @@ from typing import List, Dict
 
 from app.db.models import (
     Competition, CompetitionRegistration,
-    TeamMember, User, CompetitionLevel
+    TeamMember, User
 )
 from app.crud.competition import (
     create_competition as crud_create_competition,
@@ -25,7 +25,7 @@ from app.crud.competition import (
     update_competition as crud_update_competition,
     delete_competition,
     register_competition,
-    get_competition_teams, list_all_competition_levels
+    get_competition_teams
 )
 from app.crud.competition_announcement import (
     create_announcement,
@@ -58,9 +58,6 @@ def create_competition(db: Session, competition_in: CompetitionCreate, current_u
 
 def list_competitions(db: Session) -> List[Competition]:
     return list_all_competitions(db)
-
-def list_competition_levels(db: Session) -> List[CompetitionLevel]:
-    return list_all_competition_levels(db)
 
 def get_competition_detail_info(db: Session, competition_id: int) -> Competition:
     """

--- a/FrontEnd/app/article/page.tsx
+++ b/FrontEnd/app/article/page.tsx
@@ -227,7 +227,7 @@ function ArticleListPageContent() {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center h-screen gap-4">
+      <div className="flex-1 min-h-0 flex justify-center items-center h-screen gap-4">
         <Spinner size="lg" color="primary" />
         <p>加载文章中...</p>
       </div>
@@ -238,9 +238,6 @@ function ArticleListPageContent() {
     return (
       <div
         className="flex-1 min-h-0 container mx-auto p-4 flex"
-        style={{
-          marginTop: mounted ? (isLoggedIn ? "114px" : "60px") : "60px",
-        }}
       >
         <FilterSidebar
           //@ts-ignore

--- a/FrontEnd/app/competition/create/page.tsx
+++ b/FrontEnd/app/competition/create/page.tsx
@@ -1,27 +1,24 @@
 "use client"
-import React, {useState, useEffect} from "react";
+import React, {useState} from "react";
 import { useRouter } from "next/navigation";
 import { withAdmin } from "@/lib/auth-guards";
 import { Input, Button, Select, SelectItem, DateInput } from "@heroui/react";
 import { CalendarDateTime } from "@internationalized/date";
 import MyEditor from "@/components/IOEditor";
 import toast from "react-hot-toast";
-import {Competition, CompetitionLevel, CompetitionType} from "@/modules/competition/competition.model";
-import {calendarDateUTCToday, parseDate} from "@/lib/date";
-import {createCompetition, fetchCompetitionLevels} from "@/modules/competition/competition.api";
+import {Competition, COMPETITION_LEVELS, UNDEFINED_COMPETITION_SUBTYPE} from "@/modules/competition/competition.model";
+import {calendarDateUTCToday, truncateToDate, parseDate} from "@/lib/date";
+import {createCompetition} from "@/modules/competition/competition.api";
 import {uploadImage} from "@/modules/global/global.api";
-import LoadingPage from "@/components/LoadingPage";
 
 function CreateCompetitionPageContent() {
   const router = useRouter();
 
-  const [loading, setLoading] = useState(true);
-  const [loadFailed, setLoadFailed] = useState(false);
   const [name, setName] = useState("");
   const [details, setDetails] = useState("");
   const [organizer, setOrganizer] = useState("");
-  const [competitionLevelKey, setCompetitionLevelKey] = useState("");
-  const [competitionSubtypeKey, setCompetitionSubtypeKey] = useState("");
+  const [competitionLevel, setCompetitionLevel] = useState("");
+  const [competitionSubtype, setCompetitionSubtype] = useState("");
   // 日期使用 CalendarDateTime
   const [signUpStartDate, setSignUpStartDate] = useState<CalendarDateTime | null>(calendarDateUTCToday());
   const [signUpEndDate, setSignUpEndDate] = useState<CalendarDateTime | null>(calendarDateUTCToday());
@@ -29,8 +26,6 @@ function CreateCompetitionPageContent() {
   const [competitionEndDate, setCompetitionEndDate] = useState<CalendarDateTime | null>(calendarDateUTCToday());
   const [coverImage, setCoverImage] = useState("");
   const [coverPreview, setCoverPreview] = useState("");
-
-  const [competitionLevels, setCompetitionLevels] = useState<CompetitionLevel[]>([]);
 
   // 从 AuthStore 获取登录状态
   //const isLoggedIn = true; // 管理员页面必定是登录状态
@@ -61,8 +56,8 @@ function CreateCompetitionPageContent() {
       !name ||
       !details ||
       !organizer ||
-      !competitionLevelKey ||
-      !competitionSubtypeKey ||
+      !competitionLevel ||
+      !competitionSubtype ||
       !signUpStartDate ||
       !signUpEndDate ||
       !competitionStartDate ||
@@ -77,13 +72,13 @@ function CreateCompetitionPageContent() {
       name,
       details,
       organizer,
-      competition_level_key: competitionLevelKey,
-      competition_subtype_key: competitionSubtypeKey,
-      sign_up_start_time: parseDate(signUpStartDate).toISOString(),
-      sign_up_end_time: parseDate(signUpEndDate).toISOString(),
-      competition_start_time: parseDate(competitionStartDate).toISOString(),
-      competition_end_time: parseDate(competitionEndDate).toISOString(),
-      cover_image: coverImage,
+      competition_level: competitionLevel,
+      competition_subtype: (competitionSubtype === UNDEFINED_COMPETITION_SUBTYPE) ? null : competitionSubtype,
+      sign_up_start_time: parseDate(truncateToDate(signUpStartDate)).toISOString(),
+      sign_up_end_time: parseDate(truncateToDate(signUpEndDate)).toISOString(),
+      competition_start_time: parseDate(truncateToDate(competitionStartDate)).toISOString(),
+      competition_end_time: parseDate(truncateToDate(competitionEndDate)).toISOString(),
+      cover_image: coverImage
     };
 
     const result = await createCompetition(data)
@@ -96,42 +91,6 @@ function CreateCompetitionPageContent() {
       console.log(result.value);
     }
   };
-  
-  useEffect(() => {
-    const loadResources = async () => {
-      await Promise.all([
-        (async () => {
-          const result = await fetchCompetitionLevels();
-
-          if (result.ok) {
-            console.log(result.value);
-            setCompetitionLevels(result.value);
-          }
-          else {
-            toast.error("比赛等级加载失败！");
-            console.log(result.value);
-            setLoadFailed(true);
-          }
-        })()
-      ]);
-
-      setLoading(false);
-    }
-
-    void loadResources();
-  }, []);
-
-  if (loading) {
-    return (
-      <LoadingPage />
-    )
-  }
-
-  if (loadFailed) {
-    return (
-      <LoadingPage />
-    )
-  }
 
   return (
     <div className="flex-1 min-h-0 container mx-auto p-4 w-3/5">
@@ -142,41 +101,45 @@ function CreateCompetitionPageContent() {
 
         {/* 移除比赛类型 */}
 
-        <Select label="比赛等级" selectedKeys={[competitionLevelKey]} onSelectionChange={(keys) => {
+        <Select label="比赛等级" selectedKeys={[competitionLevel]} onSelectionChange={(keys) => {
           const value = Array.from(keys)[0] as string;
-          setCompetitionLevelKey(value);
-          setCompetitionSubtypeKey("");
+          setCompetitionLevel(value);
+          setCompetitionSubtype("");
         }} required>
           {
-            competitionLevels.map((level) => {
+            COMPETITION_LEVELS.map((level) => {
               return (
-                <SelectItem key={level.key}>{level.translation}</SelectItem>
+                <SelectItem key={level.value}>{level.value}</SelectItem>
               );
             })
           }
         </Select>
 
-        {competitionLevelKey && (
-          <Select label="比赛子类型" selectedKeys={[competitionSubtypeKey]} onSelectionChange={(keys) => {
+        {competitionLevel && (
+          <Select label="比赛子类型" selectedKeys={[competitionSubtype]} onSelectionChange={(keys) => {
             const value = Array.from(keys)[0] as string;
-            setCompetitionSubtypeKey(value)
+            setCompetitionSubtype(value)
           }} required>
-            {
-              competitionLevels.find(level => (level.key == competitionLevelKey))!.subtypes.map((subtype) => {
-                return (<SelectItem key={subtype.key}>{subtype.translation}</SelectItem>)
-              })
-            }
+            {(() => {
+              const subtypes = COMPETITION_LEVELS.find(level => (level.value == competitionLevel))!.subtypes;
+
+              return (subtypes) ?
+                subtypes.map((subtype) => {
+                  return (<SelectItem key={subtype.value}>{subtype.value}</SelectItem>)
+                }) :
+                [(<SelectItem key={UNDEFINED_COMPETITION_SUBTYPE}>{UNDEFINED_COMPETITION_SUBTYPE}</SelectItem>)]
+            })()}
           </Select>
         )}
 
         {/* 四个 DateInput */}
         <div className="flex gap-4">
-          <DateInput label="报名开始时间" value={signUpStartDate} onChange={setSignUpStartDate} granularity={"second"} isRequired/>
-          <DateInput label="报名结束时间" value={signUpEndDate} onChange={setSignUpEndDate} granularity={"second"} isRequired />
+          <DateInput label="报名开始时间" value={signUpStartDate} onChange={setSignUpStartDate} granularity={"day"} isRequired/>
+          <DateInput label="报名结束时间" value={signUpEndDate} onChange={setSignUpEndDate} granularity={"day"} isRequired />
         </div>
         <div className="flex gap-4">
-          <DateInput label="比赛开始时间" value={competitionStartDate} onChange={setCompetitionStartDate} granularity={"second"} isRequired />
-          <DateInput label="比赛结束时间" value={competitionEndDate} onChange={setCompetitionEndDate} granularity={"second"} isRequired />
+          <DateInput label="比赛开始时间" value={competitionStartDate} onChange={setCompetitionStartDate} granularity={"day"} isRequired />
+          <DateInput label="比赛结束时间" value={competitionEndDate} onChange={setCompetitionEndDate} granularity={"day"} isRequired />
         </div>
 
         <div>

--- a/FrontEnd/app/page.tsx
+++ b/FrontEnd/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import CompetitionCard from '@/components/Card/CompetitionCard';
-import toast from "react-hot-toast";
 import {Competition, CompetitionLevel} from "@/modules/competition/competition.model";
 
 export default function HomePage() {
@@ -18,9 +17,7 @@ export default function HomePage() {
       details: '全国大学生数学建模竞赛是面向全国大学生的群众性科技活动，旨在激励学生学习数学的积极性。',
       organizer: '深圳大学',
       competition_level: 'I类竞赛',
-      competition_level_key: "",
       competition_subtype: '数学建模',
-      competition_subtype_key: "",
       cover_image: '/hero-background.png',
       created_at: new Date('2024-01-01').toISOString(),
       updated_at: new Date('2024-01-01').toISOString(),
@@ -35,9 +32,7 @@ export default function HomePage() {
       details: 'ACM国际大学生程序设计竞赛是世界上公认的规模最大、水平最高的国际大学生程序设计竞赛。',
       organizer: '深圳大学',
       competition_level: 'I类竞赛',
-      competition_level_key: "",
       competition_subtype: '程序设计',
-      competition_subtype_key: "",
       cover_image: '/function-demo.png',
       created_at: new Date('2024-01-01').toISOString(),
       updated_at: new Date('2024-01-01').toISOString()
@@ -52,9 +47,7 @@ export default function HomePage() {
       details: '中国国际"互联网+"大学生创新创业大赛旨在深化高等教育综合改革，激发大学生的创造力。',
       organizer: '深圳大学',
       competition_level: 'II类竞赛',
-      competition_level_key: "",
       competition_subtype: '创业实践',
-      competition_subtype_key: "",
       cover_image: '/big-data-institute.png',
       created_at: new Date('2024-01-01').toISOString(),
       updated_at: new Date('2024-01-01').toISOString()
@@ -117,6 +110,15 @@ export default function HomePage() {
 
   return (
     <>
+      <style jsx>{`
+        .hide-scrollbar::-webkit-scrollbar {
+          display: none;
+        }
+        .hide-scrollbar {
+          -ms-overflow-style: none;
+          scrollbar-width: none;
+        }
+      `}</style>
       <div className="relative flex-1 min-h-0 overflow-hidden">
       <div 
         className="absolute inset-0 transition-transform duration-1000 ease-in-out"
@@ -264,7 +266,6 @@ export default function HomePage() {
               <CompetitionCard
                 key={competition.id}
                 competition={competition}
-                competitionLevels={competitionLevels}
                 onClick={(id) => console.log('点击竞赛:', id)} />
             ))}
           </div>

--- a/FrontEnd/components/Card/CompetitionCard.tsx
+++ b/FrontEnd/components/Card/CompetitionCard.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import { Trash2, Pencil } from "lucide-react";
 import { formatDate } from "@/lib/date";
-import {Competition, CompetitionLevel} from "@/modules/competition/competition.model";
+import {Competition, COMPETITION_LEVELS} from "@/modules/competition/competition.model";
 
 interface CompetitionCardProps {
   competition: Competition;
-  competitionLevels: CompetitionLevel[] | null;
   isAdmin?: boolean;
   onDelete?: (id: number) => void;
   onClick?: (id: number) => void;
@@ -21,23 +20,16 @@ const competitionLevelColors = [
 
 const CompetitionCard: React.FC<CompetitionCardProps> = ({
   competition,
-  competitionLevels,
   isAdmin = false,
   onDelete, 
   onClick
 }) => {
   if (!competition) return null;
 
-  const [competitionLevelColorDict, setCompetitionLevelColorDict] = useState<Record<string, string> | null>(null);
-  useEffect(() => {
-    if (competitionLevels) {
-      const dict: Record<string, string> = {};
-      competitionLevels.forEach((level, index) => {
-        dict[level.key] = competitionLevelColors[index % competitionLevelColors.length];
-      });
-      setCompetitionLevelColorDict(dict);
-    }
-  }, [competitionLevels])
+  const competitionLevelColorDict: Record<string, string> = {};
+  COMPETITION_LEVELS.forEach((level, index) => {
+    competitionLevelColorDict[level.value] = competitionLevelColors[index % competitionLevelColors.length];
+  });
 
   const handleClick = () => {
     if (onClick) onClick(competition.id!);
@@ -65,10 +57,15 @@ const CompetitionCard: React.FC<CompetitionCardProps> = ({
             className={`text-white text-xs px-3 py-1 rounded-full font-medium`
           }
             style={{
-              backgroundColor: competitionLevelColorDict ? competitionLevelColorDict[competition.competition_level_key] : competitionLevelColors[0]
+              backgroundColor: competitionLevelColorDict[competition.competition_level]
             }}
           >
-            {`${competition.competition_level} - ${competition.competition_subtype}`}
+            {
+              competition.competition_subtype ?
+                `${competition.competition_level} - ${competition.competition_subtype}` :
+                competition.competition_level
+            }
+
           </span>
         </div>
       </div>
@@ -84,7 +81,7 @@ const CompetitionCard: React.FC<CompetitionCardProps> = ({
         />
         <div className="flex justify-between items-center text-xs text-gray-500">
           <span>
-            {formatDate(competition.created_at)}
+            {formatDate(competition.created_at!)}
           </span>
         </div>
       </div>

--- a/FrontEnd/lib/date.ts
+++ b/FrontEnd/lib/date.ts
@@ -4,44 +4,16 @@
  * 2. CalendarDateTime仅用于存储本地时间
  */
 
-// Deterministic date formatting to YYYY-MM-DD (day precision only)
-// Automatically converts to local time
 import {CalendarDateTime} from "@internationalized/date";
 
-export function formatDate(
-  value: Date | string | number | null | undefined
-): string {
-  if (value === null || value === undefined) return "";
+/**
+ * 获取YYYY-MM-DD格式的日期字符串
+ * @param value 日期
+ */
+export function formatDate(value: Date | string): string {
+  const date = (value instanceof Date) ? value : new Date(value);
 
-  let d: Date;
-
-  if (typeof value === "string") {
-    // Try to parse ISO-like string first
-    d = new Date(value);
-    if (isNaN(d.getTime())) {
-      // Fallback: manually extract YYYY-MM-DD from common formats
-      const m = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
-      if (m) return `${m[1]}-${m[2]}-${m[3]}`;
-      const m2 = value.match(/^(\d{4})[\/-](\d{1,2})[\/-](\d{1,2})/);
-      if (m2) {
-        const y = m2[1];
-        const mo = m2[2].padStart(2, "0");
-        const day = m2[3].padStart(2, "0");
-        return `${y}-${mo}-${day}`;
-      }
-      return ""; // cannot parse
-    }
-  } else {
-    d = new Date(value);
-    if (isNaN(d.getTime())) return "";
-  }
-
-  // Use local time methods to convert to local date
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-
-  return `${year}-${month}-${day}`;
+  return `${date.getFullYear().toString().padStart(4, "0")}-${(date.getMonth() + 1).toString().padStart(2, "0")}-${(date.getDate()).toString().padStart(2, "0")}`
 }
 
 //获取今日CalendarDateTime日期
@@ -49,40 +21,17 @@ export function calendarDateUTCToday(): CalendarDateTime {
   return parseCalendarDateTime(new Date());
 }
 
-export function parseDate(calendarDate: CalendarDateTime): Date {
-  return new Date(calendarDate.year, calendarDate.month - 1, calendarDate.day,
-    calendarDate.hour, calendarDate.minute, calendarDate.second);
+export function parseDate(calendarDateTime: CalendarDateTime): Date {
+  return new Date(calendarDateTime.year, calendarDateTime.month - 1, calendarDateTime.day,
+    calendarDateTime.hour, calendarDateTime.minute, calendarDateTime.second, calendarDateTime.millisecond);
 }
 
 export function parseCalendarDateTime(date: Date): CalendarDateTime {
   return new CalendarDateTime(date.getFullYear(), date.getMonth() + 1, date.getDate(),
-    date.getHours(), date.getMinutes(), date.getSeconds());
+    date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds());
 }
 
-/*
-// Deterministic date formatting to YYYY-MM-DD (day precision only)
-export function formatDate(value: Date | string | number | null | undefined): string {
-  if (value === null || value === undefined) return "";
-  // If string already in ISO-like format, slice the date part
-  if (typeof value === "string") {
-    // Normalize common formats: 2025-09-07T00:00:00Z or 2025-09-07 00:00:00
-    const m = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
-    if (m) return `${m[1]}-${m[2]}-${m[3]}`;
-    // 2025/9/7 or 2025/09/07 -> normalize to YYYY-MM-DD
-    const m2 = value.match(/^(\d{4})[\/-](\d{1,2})[\/-](\d{1,2})/);
-    if (m2) {
-      const y = m2[1];
-      const mo = m2[2].padStart(2, "0");
-      const d = m2[3].padStart(2, "0");
-      return `${y}-${mo}-${d}`;
-    }
-    // Fallback to Date parsing
-  }
-  const d = new Date(value as any);
-  if (isNaN(d.getTime())) return "";
-  const year = d.getUTCFullYear();
-  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(d.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
+export function truncateToDate(calendarDateTime: CalendarDateTime): CalendarDateTime {
+  return new CalendarDateTime(calendarDateTime.year, calendarDateTime.month, calendarDateTime.day,
+    0, 0, 0, 0)
 }
-*/

--- a/FrontEnd/modules/competition/competition.api.ts
+++ b/FrontEnd/modules/competition/competition.api.ts
@@ -2,7 +2,6 @@ import {API_BASE_URL} from "@/CONFIG";
 import {
   Competition,
   CompetitionAnnouncement,
-  CompetitionLevel,
   TeamInfo
 } from "@/modules/competition/competition.model";
 import {Result} from "@/lib/result";
@@ -62,35 +61,6 @@ export async function fetchCompetitions(): Promise<Result<Competition[], Error>>
     }
 
   } catch (error) {
-    return {
-      ok: false,
-      value: error as Error
-    };
-  }
-}
-
-/**
- * 获取全部赛事等级（内含赛事子类型）
- */
-export async function fetchCompetitionLevels(): Promise<Result<CompetitionLevel[], Error>> {
-  try {
-    const response = await fetch(`${API_BASE_URL}/api/competitions/levels`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem("access_token") || ""}`,
-      },
-    });
-
-    if (response.ok) {
-      return {
-        ok: true,
-        value: await response.json()
-      };
-    }
-    else {
-      throwError("无法加载所有比赛等级！");
-    }
-  }
-  catch (error) {
     return {
       ok: false,
       value: error as Error

--- a/FrontEnd/modules/competition/competition.model.ts
+++ b/FrontEnd/modules/competition/competition.model.ts
@@ -1,3 +1,58 @@
+import {FilterCategory} from "@/modules/global/global.model";
+import {getCompetitionFilterCategories} from "@/modules/competition/competition.service";
+
+/**
+ * 比赛专用筛选类型
+ */
+export type CompetitionFilterCategoryKey = "competition_level";
+
+/**
+ * 比赛等级常量
+ */
+export const COMPETITION_LEVELS: CompetitionLevel[] = [
+  {
+    value: "I 类竞赛",
+    subtypes: [
+      {
+        value: "中国\"互联网+\"大学生创新创业大赛"
+      },
+      {
+        value: "\"挑战杯\"课外学术科技作品竞赛"
+      },
+      {
+        value: "\"挑战杯\"大学生创业计划竞赛"
+      }
+    ]
+  },
+  {
+    value: "II 类竞赛",
+    subtypes: [
+      {
+        value: "(A) 类"
+      },
+      {
+        value: "(B) 类"
+      },
+      {
+        value: "(C) 类"
+      }
+    ]
+  },
+  {
+    value: "III 类竞赛"
+  }
+]
+
+/**
+ * 根据前端所存储的比赛等级常量所生成的筛选字样
+ */
+export const COMPETITION_FILTER_CATEGORIES: FilterCategory<CompetitionFilterCategoryKey>[] = getCompetitionFilterCategories(COMPETITION_LEVELS);
+
+/**
+ * 等级无子类型下的常量值
+ */
+export const UNDEFINED_COMPETITION_SUBTYPE = "未分类";
+
 /**
  * 赛事数据模型
  */
@@ -10,10 +65,8 @@ export type Competition = {
   competition_end_time: string;
   details: string;
   organizer: string;
-  competition_level?: string;
-  competition_level_key: string;
-  competition_subtype?: string;
-  competition_subtype_key: string;
+  competition_level: string;
+  competition_subtype: string | null;
   cover_image: string;
   created_at?: string;
   updated_at?: string;
@@ -32,28 +85,18 @@ export type CompetitionAnnouncement = {
 };
 
 /**
- * 赛事类型数据模型
- */
-export type CompetitionType = {
-  key: string,
-  translation: string
-}
-
-/**
  * 赛事子类型数据模型
  */
 export type CompetitionSubtype = {
-  key: string,
-  translation: string
+  value: string,
 }
 
 /**
  * 赛事等级数据模型
  */
 export type CompetitionLevel = {
-  key: string,
-  translation: string,
-  subtypes: CompetitionSubtype[]
+  value: string,
+  subtypes?: CompetitionSubtype[]
 }
 
 /**

--- a/FrontEnd/modules/competition/competition.service.ts
+++ b/FrontEnd/modules/competition/competition.service.ts
@@ -1,37 +1,22 @@
 import {FilterCategory} from "@/modules/global/global.model";
-import {fetchCompetitionLevels} from "@/modules/competition/competition.api";
-import {Result} from "@/lib/result";
+import {CompetitionFilterCategoryKey, CompetitionLevel} from "@/modules/competition/competition.model";
 
-export async function getCompetitionFilterCategories(): Promise<Result<FilterCategory[], Error>> {
-  const levelsFetchResult = await fetchCompetitionLevels();
-  if (!levelsFetchResult.ok) {
-    return {
-      ok: false,
-      value: Error("筛选相关信息获取失败！")
-    };
-  }
-
-  const filterCategories: FilterCategory[] = [
+export function getCompetitionFilterCategories(levels: CompetitionLevel[]): FilterCategory<CompetitionFilterCategoryKey>[] {
+  return [
     {
       title: "比赛等级",
       key: "competition_level",
-      options: levelsFetchResult.value.map((level) => {
+      options: levels.map((level) => {
         return {
-          label: level.translation,
-          key: level.key,
-          children: level.subtypes.map((subtype) => {
+          value: level.value,
+          children: level.subtypes ? level.subtypes.map((subtype) => {
             return {
-              label: subtype.translation,
-              key: subtype.key
+              value: subtype.value,
+              children: []
             }
-          })
+          }) : undefined
         }
       })
     }
   ];
-
-  return {
-    ok: true,
-    value: filterCategories
-  };
 }

--- a/FrontEnd/modules/global/global.model.ts
+++ b/FrontEnd/modules/global/global.model.ts
@@ -1,11 +1,10 @@
 export type FilterNode = {
-  label: string,
-  key: string,
+  value: string,
   children?: FilterNode[]
 }
 
-export type FilterCategory = {
+export type FilterCategory<T extends string = string> = {
   title: string,
-  key: string,
+  key: T,
   options: FilterNode[]
 }


### PR DESCRIPTION
「前端」
1.取消比赛等级与子类型后端化获取，改为前端自行常量存储
2.若干个逻辑与UI设计细节的改动

「后端」
1.取消比赛等级与子类型后端化存储机制，令数据库仅直接存储字面量
2.将announcements字段加入Competition的Schema模型，从而优化获取公告endpoint的代码逻辑 3.修改返回给前端的Competition模型datetime类型字段统一为UTC时区ISO格式